### PR TITLE
Upgrade to marked 0.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bugs": { "url": "http://github.com/gjtorikian/roaster/issues" },
 
   "dependencies"    : {
-                        "marked" : "0.2.8",
+                        "marked" : "0.2.9",
                         "emoji-images" : "0.0.2",
                         "task-lists": "0.0.2"
                       },


### PR DESCRIPTION
Would be awesome to get a release with 0.2.9 for this fix: https://github.com/chjj/marked/pull/139
