### PR TITLE
Allow any patch version of task-lists dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies"    : {
                         "marked" : "0.2.9",
                         "emoji-images" : "0.0.2",
-                        "task-lists": "0.1.0",
+                        "task-lists": "0.1.x",
                         "toc": "0.3.0"
                       },
 


### PR DESCRIPTION
This allows roaster to use the latest task-lists npm, which has licensed dependencies.
