### PR TITLE
Strip out emoji images from code tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
                       },
 
   "devDependencies": {
+    "cheerio": "0.15.0",
     "coffee-script": "~1.6.1",
     "grunt": "~0.4.0",
     "grunt-contrib-coffee": "~0.4.0",

--- a/src/roaster.coffee
+++ b/src/roaster.coffee
@@ -5,6 +5,7 @@ Path = require 'path'
 marked = require 'marked'
 emoji = require 'emoji-images'
 taskLists = require 'task-lists'
+cheerio = require 'cheerio'
 
 emojiFolder = Path.join(Path.dirname( require.resolve('emoji-images') ), "pngs")
 
@@ -17,7 +18,15 @@ module.exports = (file, opts, callback) ->
   conversion = (data) ->
     mdToHtml = marked(data)
     emojified = emoji(mdToHtml, emojiFolder, 20)
-    contents = taskLists(emojified)
+
+    # emoji-images is too aggressive; let's replace images in monospace tags with the actual emoji text
+    $ = cheerio.load(emojified)
+    $('pre img').each (index, element) ->
+      $('pre img').replaceWith $(this).attr('title')
+    $('code img').each (index, element) ->
+      $('code img').replaceWith $(this).attr('title')
+
+    contents = taskLists($.html())
 
   if typeof opts is 'function'
     callback = opts

--- a/test/fixtures/emoji_bad.md
+++ b/test/fixtures/emoji_bad.md
@@ -1,0 +1,5 @@
+``` ruby
+not :trollface:
+```
+
+wow `that is nice :smiley:`

--- a/test/roaster-spec.coffee
+++ b/test/roaster-spec.coffee
@@ -23,15 +23,19 @@ describe "roaster", ->
     it "returns emoji it knows", ->
       roaster Path.join(fixtures_dir, "emoji.md"), {isFile: true}, (err, contents) ->
         expect(err).toBeNull()
-        expect(contents).toMatch '<p><img class="emoji" title=":trollface:" alt="trollface" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/trollface.png" height="20"></p>\n<p><img class="emoji" title=":shipit:" alt="shipit" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/shipit.png" height="20"></p>\n<p><img class="emoji" title=":smiley:" alt="smiley" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/smiley.png" height="20"></p>'
+        expect(contents).toEqual '<p><img class="emoji" title=":trollface:" alt="trollface" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/trollface.png" height="20"></p>\n<p><img class="emoji" title=":shipit:" alt="shipit" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/shipit.png" height="20"></p>\n<p><img class="emoji" title=":smiley:" alt="smiley" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/smiley.png" height="20"></p>'
     it "can sanitize and return", ->
       roaster Path.join(fixtures_dir, "emoji.md"), {isFile: true, sanitize:true}, (err, contents) ->
         expect(err).toBeNull()
-        expect(contents).toMatch '<p><img class="emoji" title=":trollface:" alt="trollface" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/trollface.png" height="20"></p>\n<p><img class="emoji" title=":shipit:" alt="shipit" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/shipit.png" height="20"></p>\n<p><img class="emoji" title=":smiley:" alt="smiley" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/smiley.png" height="20"></p>'
+        expect(contents).toEqual '<p><img class="emoji" title=":trollface:" alt="trollface" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/trollface.png" height="20"></p>\n<p><img class="emoji" title=":shipit:" alt="shipit" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/shipit.png" height="20"></p>\n<p><img class="emoji" title=":smiley:" alt="smiley" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/smiley.png" height="20"></p>'
     it "does nothing to unknown emoji", ->
       roaster ":lala:", (err, contents) ->
         expect(err).toBeNull()
-        expect(contents).toMatch ':lala:'
+        expect(contents).toEqual '<p>:lala:</p>\n'
+    it "does not mess up coded emoji", ->
+      roaster Path.join(fixtures_dir, "emoji_bad.md"), {isFile: true}, (err, contents) ->
+        expect(err).toBeNull()
+        expect(contents).toEqual '<pre><code class="lang-ruby">not :trollface:\n</code></pre>\n<p>wow <code>that is nice :smiley:</code></p>'
 
   # describe "headers", ->
   #   [toc, result, resultShort] = []


### PR DESCRIPTION
Closes https://github.com/gjtorikian/roaster/issues/11

The emoji renderer is too aggressive when it comes to replacing images. This PR now uses cheerio to just manipulate the DOM in the cases where emoji is improperly inserted.

@kevinsawicki this is going out now as `1.0.5`.
