### PR TITLE
Move cheerio from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   "dependencies"    : {
                         "marked" : "0.3.1",
                         "emoji-images" : "0.0.2",
-                        "task-lists": "0.1.2"
+                        "task-lists": "0.1.2",
+                        "cheerio": "0.15.0"
                       },
 
   "devDependencies": {
-    "cheerio": "0.15.0",
     "coffee-script": "~1.6.1",
     "grunt": "~0.4.0",
     "grunt-contrib-coffee": "~0.4.0",


### PR DESCRIPTION
Getting an `Uncaught Error: Cannot find module 'cheerio'` when trying to use `roaster` 1.0.5
