### PR TITLE
Make all tests run

### DIFF
--- a/test/roaster-spec.coffee
+++ b/test/roaster-spec.coffee
@@ -1,6 +1,7 @@
 roaster = require '../lib/roaster'
 Path = require 'path'
 Fs = require 'fs'
+cheerio = require 'cheerio'
 
 fixtures_dir = Path.join(__dirname, "fixtures")
 
@@ -36,9 +37,25 @@ describe "roaster", ->
 
       runs ->
         [err, contents] = callback.mostRecentCall.args
-
         expect(err).toBeNull()
-        expect(contents).toEqual '<p><img class="emoji" title=":trollface:" alt="trollface" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/trollface.png" height="20"></p>\n<p><img class="emoji" title=":shipit:" alt="shipit" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/shipit.png" height="20"></p>\n<p><img class="emoji" title=":smiley:" alt="smiley" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/smiley.png" height="20"></p>'
+
+        $ = cheerio.load(contents)
+        expect($("p img").length).toBe 3
+
+        expect($('p img[title=":trollface:"]').length).toBe 1
+        expect($('p img[title=":trollface:"]').attr("class")).toEqual "emoji"
+        expect($('p img[title=":trollface:"]').attr("alt")).toEqual "trollface"
+        expect($('p img[title=":trollface:"]').attr("src")).toMatch /.*trollface\.png$/
+
+        expect($('p img[title=":shipit:"]').length).toBe 1
+        expect($('p img[title=":shipit:"]').attr("class")).toEqual "emoji"
+        expect($('p img[title=":shipit:"]').attr("alt")).toEqual "shipit"
+        expect($('p img[title=":shipit:"]').attr("src")).toMatch /.*shipit\.png$/
+
+        expect($('p img[title=":smiley:"]').length).toBe 1
+        expect($('p img[title=":smiley:"]').attr("class")).toEqual "emoji"
+        expect($('p img[title=":smiley:"]').attr("alt")).toEqual "smiley"
+        expect($('p img[title=":smiley:"]').attr("src")).toMatch /.*smiley\.png$/
     it "can sanitize and return", ->
       callback = jasmine.createSpy()
       roaster Path.join(fixtures_dir, "emoji.md"), {isFile: true, sanitize:true}, callback
@@ -48,9 +65,25 @@ describe "roaster", ->
 
       runs ->
         [err, contents] = callback.mostRecentCall.args
-
         expect(err).toBeNull()
-        expect(contents).toEqual '<p><img class="emoji" title=":trollface:" alt="trollface" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/trollface.png" height="20"></p>\n<p><img class="emoji" title=":shipit:" alt="shipit" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/shipit.png" height="20"></p>\n<p><img class="emoji" title=":smiley:" alt="smiley" src="/Users/garentorikian/Development/roaster/node_modules/emoji-images/pngs/smiley.png" height="20"></p>'
+
+        $ = cheerio.load(contents)
+        expect($("p img").length).toBe 3
+
+        expect($('p img[title=":trollface:"]').length).toBe 1
+        expect($('p img[title=":trollface:"]').attr("class")).toEqual "emoji"
+        expect($('p img[title=":trollface:"]').attr("alt")).toEqual "trollface"
+        expect($('p img[title=":trollface:"]').attr("src")).toMatch /.*trollface\.png$/
+
+        expect($('p img[title=":shipit:"]').length).toBe 1
+        expect($('p img[title=":shipit:"]').attr("class")).toEqual "emoji"
+        expect($('p img[title=":shipit:"]').attr("alt")).toEqual "shipit"
+        expect($('p img[title=":shipit:"]').attr("src")).toMatch /.*shipit\.png$/
+
+        expect($('p img[title=":smiley:"]').length).toBe 1
+        expect($('p img[title=":smiley:"]').attr("class")).toEqual "emoji"
+        expect($('p img[title=":smiley:"]').attr("alt")).toEqual "smiley"
+        expect($('p img[title=":smiley:"]').attr("src")).toMatch /.*smiley\.png$/
     it "does nothing to unknown emoji", ->
       roaster ":lala:", (err, contents) ->
         expect(err).toBeNull()
@@ -66,7 +99,7 @@ describe "roaster", ->
         [err, contents] = callback.mostRecentCall.args
 
         expect(err).toBeNull()
-        expect(contents).toEqual '<pre><code class="lang-ruby">not :trollface:\n</code></pre>\n<p>wow <code>that is nice :smiley:</code></p>'
+        expect(contents).toEqual '<pre><code class="lang-ruby">not :trollface:\n</code></pre>\n<p>wow <code>that is nice :smiley:</code></p>\n'
   # describe "headers", ->
   #   [toc, result, resultShort] = []
 


### PR DESCRIPTION
While working on https://github.com/atom/markdown-preview/issues/84 I noticed that not all tests in roaster were being run (because of the async nature of roaster when it loads contents from a file).

Also, the current tests check for string equality, where one string includes `/Users/garentorikian/Development/roaster/`. While I've considered renaming my account name to "garentorikian", making the tests more robust seems like a better approach. :smile:  (Also, there can be only one garentorikian!)

This PR makes all tests run (with a little help from spies :ghost:), and fixes tests so that they don't depend on machine account names (with a little help from cheerio).

cc @gjtorikian
