### PR TITLE
Use js-yaml 3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "emoji-images": "0.0.2",
     "task-lists": "0.2.0",
     "cheerio": "0.15.0",
-    "js-yaml": "3.1.0",
+    "js-yaml": "3.6.1",
     "underscore": "1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This change will reduce the size of Atom.app by 7.5 MB. The version of js-yaml currently in use - 3.1.0 - includes sample files, one of which is very large. Newer versions do not include these files by default.

The tests pass and I have not seen any issues inside the application during my brief testing.

I was surprised to find that this low-hanging fruit of a size reduction has been around for so long. For a further significant size reduction, I suggest considering whether the inclusion of emoji-images is worth the cost.
